### PR TITLE
Fix to allow file to build on MacOS

### DIFF
--- a/10.0.0.2/Dockerfile
+++ b/10.0.0.2/Dockerfile
@@ -25,7 +25,7 @@ COPY kernel_settings.sh /tmp/
 RUN echo "IIB_10:" > /etc/debian_chroot  && \
     touch /var/log/syslog && \
     chown syslog:adm /var/log/syslog && \
-    chmod +x /tmp/kernel_settings.sh && \
+    chmod +x /tmp/kernel_settings.sh;sync && \
     /tmp/kernel_settings.sh
 
 # Create user to run as


### PR DESCRIPTION
Building this file caused a "file busy" error when trying to run /tmp/kernel_settings.sh.

The solution is to force the previous chmod on the file
