### PR TITLE
- Removed unvisible chars at the begining of iib_manage.sh causing "docker run" to fail

### DIFF
--- a/10.0.0.11/iib-mq-server/iib_manage.sh
+++ b/10.0.0.11/iib-mq-server/iib_manage.sh
@@ -1,4 +1,4 @@
-﻿#!/bin/bash
+#!/bin/bash
 # © Copyright IBM Corporation 2015.
 #
 # All rights reserved. This program and the accompanying materials


### PR DESCRIPTION
I downloaded the pre-built image ibmcom/iib-mq-server.
When I run the image I got the following error:

standard_init_linux.go:178: exec user process caused "exec format error"

After digging a little bit I realized that the problem was in iib_manage.sh script

if we run the command : od -c iib_manage.sh in the container (accessed with an entry point of /bin/bash) or looking at iib_manage.sh in the cloned forked repo, we can see the following output:

0000000  357 273 277   #   !   /   b   i   n   /   b   a   s   h  \n   #
0000020        ©  **       C   o   p   y   r   i   g   h   t       I   B
0000040    M       C   o   r   p   o   r   a   t   i   o   n       2   0
0000060    1   5   .  \n   #  \n   #       A   l   l       r   i   g   h
0000100    t   s     

To avoid this characters I had to use an hexadecimal editor because neither "vi" nor TextEdit (I'm using a Mac), showed those weirds characters. I used the iHex editor.

Also I built and run the image without any problem.
